### PR TITLE
base_fix topic for base station coords

### DIFF
--- a/src/components/NavigationPanel/GpsCoords.tsx
+++ b/src/components/NavigationPanel/GpsCoords.tsx
@@ -11,7 +11,6 @@ interface GpsProps {
 }
 
 export const GPS = (props: GpsProps) => {
-
   const gpsTopic = new ROSLIB.Topic({
     ros: props.ROS,
     name: "/fix",
@@ -20,8 +19,8 @@ export const GPS = (props: GpsProps) => {
 
   const baseTopic = new ROSLIB.Topic({
     ros: props.ROS,
-    name: "/set_base",
-    messageType: "std_msgs/Bool",
+    name: "/base_fix",
+    messageType: "sensor_msgs/NavSatFix",
   });
 
   useEffect(() => {
@@ -29,31 +28,37 @@ export const GPS = (props: GpsProps) => {
       props.setCoord({
         id: "R",
         lat: message.latitude,
-        lng: message.longitude
+        lng: message.longitude,
       });
     });
 
     baseTopic.subscribe((message: any) => {
-      if (message.data) {
-        props.setBaseCoord({
-          id: "B",
-          lat: props.coord.lat,
-          lng: props.coord.lng
-        });
-      }
+      props.setBaseCoord({
+        id: "B",
+        lat: message.latitude,
+        lng: message.longitude,
+      });
     });
   });
   return (
     <div className="card">
       <div className="card-subtitle">GPS Coordinates</div>
       <div className="whitespace-nowrap">{`Lat: ${props.coord.lat.toPrecision(9)},  Lng: ${props.coord.lng.toPrecision(9)}`}</div>
-      <button onClick={() => {
-        props.setBaseCoord({id: "B", lat: props.coord.lat, lng: props.coord.lng});
-        baseTopic.publish(new ROSLIB.Message({
-          data: true
-        }));
-        console.log(props.coord);
-      }}>
+      <button
+        onClick={() => {
+          props.setBaseCoord({
+            id: "B",
+            lat: props.coord.lat,
+            lng: props.coord.lng,
+          });
+          baseTopic.publish(
+            new ROSLIB.Message({
+              data: true,
+            }),
+          );
+          console.log(props.coord);
+        }}
+      >
         Set Base Station
       </button>
     </div>


### PR DESCRIPTION
Get base station coordinates by subscribing to /base_fix (of type NavSatFix) instead of setting them to the current rover coordinates when /set_base is published. This is in accordance to changes in urc_software (urc_tf).